### PR TITLE
Fix buffer overflow in EAP

### DIFF
--- a/components/network/lwip/src/netif/ppp/eap.c
+++ b/components/network/lwip/src/netif/ppp/eap.c
@@ -1417,7 +1417,7 @@ static void eap_request(ppp_pcb *pcb, u_char *inp, int id, int len) {
 		}
 
 		/* Not so likely to happen. */
-		if (vallen >= len + sizeof (rhostname)) {
+		if (len - vallen >= sizeof (rhostname)) {
 			ppp_dbglog("EAP: trimming really long peer name down");
 			MEMCPY(rhostname, inp + vallen, sizeof (rhostname) - 1);
 			rhostname[sizeof (rhostname) - 1] = '\0';
@@ -1845,7 +1845,7 @@ static void eap_response(ppp_pcb *pcb, u_char *inp, int id, int len) {
 		}
 
 		/* Not so likely to happen. */
-		if (vallen >= len + sizeof (rhostname)) {
+		if (len - vallen >= sizeof (rhostname)) {
 			ppp_dbglog("EAP: trimming really long peer name down");
 			MEMCPY(rhostname, inp + vallen, sizeof (rhostname) - 1);
 			rhostname[sizeof (rhostname) - 1] = '\0';

--- a/components/network/lwip/src/netif/ppp/eap.c
+++ b/components/network/lwip/src/netif/ppp/eap.c
@@ -1326,6 +1326,12 @@ static void eap_request(ppp_pcb *pcb, u_char *inp, int id, int len) {
 #endif /* USE_SRP */
 
 	/*
+	 * Ignore requests if we're not open
+	 */
+	if (esp->es_client.ea_state <= eapClosed)
+		return;
+
+	/*
 	 * Note: we update es_client.ea_id *only if* a Response
 	 * message is being generated.  Otherwise, we leave it the
 	 * same for duplicate detection purposes.
@@ -1737,6 +1743,12 @@ static void eap_response(ppp_pcb *pcb, u_char *inp, int id, int len) {
 	u_char dig[SHA_DIGESTSIZE];
 #endif /* USE_SRP */
 
+	/*
+	 * Ignore responses if we're not open
+	 */
+	if (esp->es_server.ea_state <= eapClosed)
+		return;
+
 	if (pcb->eap.es_server.ea_id != id) {
 		ppp_dbglog("EAP: discarding Response %d; expected ID %d", id,
 		    pcb->eap.es_server.ea_id);
@@ -2042,6 +2054,12 @@ static void eap_success(ppp_pcb *pcb, u_char *inp, int id, int len) {
  */
 static void eap_failure(ppp_pcb *pcb, u_char *inp, int id, int len) {
 	LWIP_UNUSED_ARG(id);
+
+	/*
+	 * Ignore responses if we're not open
+	 */
+	if (esp->es_client.ea_state <= eapClosed)
+		return;
 
 	if (!eap_client_active(pcb)) {
 		ppp_dbglog("EAP unexpected failure message in state %s (%d)",


### PR DESCRIPTION
There's a [Pine64 fork](https://github.com/pine64/bl_iot_sdk) of your repository and I am not sure if you will cooperate somehow in the future or will take changes from each other, but I sent this pull request already to the forked repository (https://github.com/pine64/bl_iot_sdk/pull/21) and it should be fixed here as well.

I discovered that in the source code, there is a shipped old version of pppd, which is vulnerable to [CVE-2020-8597](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-8597). The change comes from this commit: https://github.com/paulusmack/ppp/commit/8d7970b8f3db727fe798b65f3377fe6787575426